### PR TITLE
PPSASCRUM-420: Fixed the CC Calculator to render the accurate non-zero Inbound Freight cost value in EDIT form

### DIFF
--- a/src/Template/Quotes/Calculators/cubicle-curtain.ctp
+++ b/src/Template/Quotes/Calculators/cubicle-curtain.ctp
@@ -1909,6 +1909,11 @@ function doCalculation(){
 		}
 		
 		$('#inbound-freight').val(ibfrtpy);
+		/* PPSASCRUM-420: start [Inbound Freight should display any non-zero value held in its 'value' attribute instead of rendering with ZERO in the EDIT CC Calculator form] */
+		if (!parseFloat($('#inbound-freight').val()) && parseFloat($('#inbound-freight').attr('value'))) {
+			$('#inbound-freight').val(parseFloat($('#inbound-freight').attr('value')));
+		}
+		/* PPSASCRUM-420: end */
 	
 	
 		if($('#inbound-freight-custom-value').val() != ''){
@@ -3170,6 +3175,9 @@ setInterval('correctColHeights()',500);
 	if(canCalculate()){	
 		$('#cannotcalculate').hide();
 		doCalculation(); 
+		/* PPSASCRUM-420: start [calling the doCalculation() function to complete all the remaining calculations and show final correct values for all including Base Price] */
+		doCalculation();
+		/* PPSASCRUM-420: end */
 	}else{
 		$('#cannotcalculate').show();
 	}


### PR DESCRIPTION
PPSASCRUM-420: Fixed the CC Calculator EDIT form to render with an accurate non-zero Inbound Freight cost value held in the 'value' attribute of this field by fixing the value evaluation and assignment during initial rendering instead of rendering with ZERO