### PR TITLE
PPSASCRUM-395: Implemented 3-Phase ruleset to reject or permit the change in Fabric or Color in EDIT Sales Order

### DIFF
--- a/src/Template/Quotes/addstep2.ctp
+++ b/src/Template/Quotes/addstep2.ctp
@@ -79,7 +79,9 @@ $(function(){
     /* PPSASCRUM-398: start [implemented button by screen right-edge inside the error flash modal default template by CakePHP to close this modal] */
     let errorDiv = $("div.message.error");
 
-    if (errorDiv.length == 1 && errorDiv.text() == 'Rule Check: Quantity cannot be less than the scheduled batch quantity.') {
+	/* PPSASCRUM-395: start [updated the ruleset flash error to be identified generically using its prefix label to address this condition for all the rulesets checks] */
+	if (errorDiv.length == 1 && errorDiv.text().startsWith("Rule Check:")) {
+	/* PPSASCRUM-395: end */
         var style = document.createElement("style");
         style.type = "text/css";
         style.innerHTML = "div.message.error:before { display: none; }";
@@ -2044,7 +2046,9 @@ function updateroomnumber(lineitemid,newroomnumber){
 
 function autoHideFlashScreen(){
     /* PPSASCRUM-398: start [disabled the auto-hiding for the default error flash modal by CakePHP specifically for the QTY ruleset 5.0 and 13.0 violation] */
-    if (!($('div.message.error').length == 1 && $('div.message.error').text() == 'Rule Check: Quantity cannot be less than the scheduled batch quantity.')) {
+	/* PPSASCRUM-395: start [updated the ruleset flash error to be identified generically using its prefix label to address this condition for all the rulesets checks] */
+    if (!($('div.message.error').length == 1 && $('div.message.error').text().startsWith("Rule Check:"))) {
+	/* PPSASCRUM-395: end */
 	    $('div.message.success,div.message.error').hide('fast');
     }
     /* PPSASCRUM-398: end */


### PR DESCRIPTION
PPSASCRUM-395: Implemented 3-Phase ruleset to reject  the change in Fabric/Color in Conditionally or Absolutely based on the Sherry Scheduling status of the line item if the line item is batched for scheduling along with an appropriate rejection message for user which stays in the screen for user to read and acknowledge it in EDIT Sales Order mode or permit the change in Fabric or Color if the user has resolved the criteria mentioned in the ecountered rejection issue or in case if the line item is not batched at all in EDIT Sales Order