### PR TITLE
PPSASCRUM-396: Implemented 3-Phase ruleset to reject or permit the deletion of line item in EDIT Sales Order

### DIFF
--- a/src/Template/Quotes/addstep2.ctp
+++ b/src/Template/Quotes/addstep2.ctp
@@ -1711,7 +1711,13 @@ function deleteLineItem(lineitemid, pageNo){
 /*PPSASCRUM-139: end*/
 	if(confirm('Are you sure you want to delete this line item?')){
 		$.fancybox.showLoading();
-		$.get('/quotes/deletelineitem/'+lineitemid+'/<?php echo $ordermode;?>',function(data){
+		/* PPSASCRUM-396: start [identifying JavaScript scriptlet reponse variant of this API, parsing and executing it upon receiving and sending data-table page number to facilitate the automatic data-table pagination navigation followed by auto-scrolling to the attempted line item for delete which failed due to ruleset rejection upon ruleset violation] */
+		$.get('/quotes/deletelineitem/'+lineitemid+'/<?php echo $ordermode;?>?page='+pageNo,function(data){
+			if (data.toString().startsWith("<script>")) {
+				const script = data.toString().substring(8, data.toString().length - 10);
+				eval(script);
+			}
+		/* PPSASCRUM-396: end */
 			if(data=="OK"){
 				/*PPSASCRUM-139: start*/
 				// updateQuoteTable();


### PR DESCRIPTION
PPSASCRUM-396: Implemented 3-Phase ruleset to reject the deletion of line item in EDIT Sales Order in Conditionally or Absolutely scenarios based on the Sherry Scheduling status of the line item if the line item is batched for scheduling along with an appropriate rejection message for user which stays in the screen for user to read and acknowledge it in EDIT Sales Order mode or permit the deletion of line item in EDIT Sales Order if the user has resolved the criteria mentioned in the ecountered rejection issue or in case if the line item is not batched at all for scheduling