### PR TITLE
PPSASCRUM-428: Fixed the discrepancy between 'Total $' displayed on Quote Builder and 'Total $' reported by 'Orders' page and 'Active Orders Report'

### DIFF
--- a/src/Controller/QuotesController.php
+++ b/src/Controller/QuotesController.php
@@ -23115,8 +23115,18 @@ class QuotesController extends AppController
 
             if ($ordermode == "order") {
                 $orderRow = $ordersTable->get($orderID);
+                /* PPSASCRUM-428: start [calculating the correct Order's Total price based on the latest Adj price changes in the EDIT SO QB] */
+                $updatedOrderTotalPrice = array_reduce($newLineItems, function($priceAccumulator, $lineItem) {
+                    $adjPrice = $lineItem["override_active"] == 1 ? 
+                        floatval($lineItem["override_price"]) : floatval($lineItem["pmi_adjusted"]);
+                    $priceAccumulator += intval($lineItem["qty"]) * $adjPrice;
+                    return $priceAccumulator;
+                }, 0);
+                /* PPSASCRUM-428: end */
                 $orderRow->quote_id = $newquoteid;
-                $orderRow->order_total = $newQuote->quote_total;
+                /* PPSASCRUM-428: start [assigning the latest evaluated Orders Total in the Orders object being persisted] */
+                $orderRow->order_total = $updatedOrderTotalPrice;
+                /* PPSASCRUM-428: end */
                 $orderRow->status = "Pre-Production";
                 $ordersTable->save($orderRow);
                 $this->logActivity(


### PR DESCRIPTION
PPSASCRUM-428: Fixed the discrepancy between 'Total $' displayed on Quote Builder and 'Total $' reported by 'Orders' page and 'Active Orders Report' by accurately calculating the Order's Total price based on the latest Adj price changes in the EDIT SO QB and persisting it in the 'order_total' column of the 'orders' table to reflect correctly in the 'Orders' screen and the 'Active Orders' spreadsheet report